### PR TITLE
Tabbyml inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# dev-env
+# Development Environment
+
+## Intent
+Containerized development tooling that can integrate with a minimal amount of host-installed dependencies. For instance, the `dev-container` workflow for vscode integrating and handling git credentials is a nice mechanism for not needing to copy credentials into the container or multiple places.
+
+## Requirements
+1. Replicate everyday development tooling to a container
+2. amd64 and arm64 support
+3. Compose file for development server - hosting multiple services
+
+## Tooling
+TabbyML for coding assistant

--- a/README.md
+++ b/README.md
@@ -5,8 +5,15 @@ Containerized development tooling that can integrate with a minimal amount of ho
 
 ## Requirements
 1. Replicate everyday development tooling to a container
-2. amd64 and arm64 support
+2. amd64 and arm64 support for the primary development container
 3. Compose file for development server - hosting multiple services
 
 ## Tooling
-TabbyML for coding assistant
+TabbyML for coding assistant capabilities
+
+## Host Machine Setup
+
+### Tabby Requirements
+- [Nvidia Container Toolkit install](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installing-with-apt)
+- [Nvidia Container Toolkit Docker Steps](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#configuring-docker)
+- [Nvidia Driver Installation](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_local)

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
   tabby:
     restart: always
-    image: tabbyml/tabby
+    image: tabbyml/tabby:20240321
     environment:
       - TABBY_DISABLE_USAGE_COLLECTION=1
     command: serve --model DeepseekCoder-6.7B --device cuda

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: '3.5'
+
+services:
+  tabby:
+    restart: always
+    image: tabbyml/tabby
+    environment:
+      - TABBY_DISABLE_USAGE_COLLECTION=1
+    command: serve --model DeepseekCoder-6.7B --device cuda
+    volumes:
+      - "$HOME/.tabby:/data"
+    ports:
+      - 8080:8080
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/dev-container/Dockerfile
+++ b/dev-container/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:22.04
+
+RUN apt update && \
+  apt install -y curl
+
+RUN groupadd --gid 1000 developer \
+    && useradd --uid 1000 --gid 1000 -m developer \
+    #
+    # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo developer ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/developer \
+    && chmod 0440 /etc/sudoers.d/developer
+
+# Golang
+RUN curl -LO https://go.dev/dl/go1.22.0.linux-amd64.tar.gz && \
+  tar -C /usr/local -xzf go1.22.0.linux-amd64.tar.gz && \
+  rm go1.22.0.linux-amd64.tar.gz
+
+# Kubectl
+RUN curl -LO https://dl.k8s.io/release/v1.29.2/bin/linux/amd64/kubectl && \
+  chmod +x ./kubectl && \
+  mv ./kubectl /usr/local/bin/kubectl
+
+# Kind
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64 && \
+  chmod +x ./kind && \
+  mv ./kind /usr/local/bin/kind
+
+# Docker CLI
+RUN curl -LO https://download.docker.com/linux/static/stable/x86_64/docker-25.0.3.tgz && \
+  tar -xzf docker-25.0.3.tgz && \
+  mv docker/docker /usr/local/bin/docker && \
+  rm -rf docker-25.0.3.tgz docker
+
+USER developer
+

--- a/dev-container/Dockerfile
+++ b/dev-container/Dockerfile
@@ -1,3 +1,5 @@
+# TODO: add an architecture variable
+
 FROM ubuntu:22.04
 
 RUN apt update && \


### PR DESCRIPTION
Adding a compose file for persistent containers - tabbyml/tabby being the first. 

- Switch compose to a explicit image tag
- Disable metrics gathering
- define `DeepseekCoder-6.7B` as the intended model per benchmarks